### PR TITLE
Fix missing server utilities

### DIFF
--- a/server/utils/emails.js
+++ b/server/utils/emails.js
@@ -88,3 +88,17 @@ export const sendStudentAssignedEmail = async ({ studentEmail, mentorName }) => 
     return { status: 500, body: { error: 'Failed to notify student.' } };
   }
 };
+
+import jwt from 'jsonwebtoken';
+
+export const generateToken = (userId) => {
+  const secret = process.env.JWT_SECRET || 'change-me';
+  return jwt.sign({ userId }, secret, { expiresIn: '1h' });
+};
+
+export const verifyToken = (token) => {
+  const secret = process.env.JWT_SECRET || 'change-me';
+  return jwt.verify(token, secret);
+};
+
+export { resend };

--- a/server/utils/resend.js
+++ b/server/utils/resend.js
@@ -1,0 +1,18 @@
+import { Resend } from 'resend';
+
+let resend;
+try {
+  resend = new Resend(process.env.RESEND_API_KEY);
+} catch (error) {
+  console.warn('⚠️ Resend API key missing. Email functionality will be mocked for development.');
+  resend = {
+    emails: {
+      send: async (emailData) => {
+        console.log('📧 MOCK EMAIL SENT:', emailData);
+        return { data: { id: 'mock-email-id' }, error: null };
+      }
+    }
+  };
+}
+
+export { resend };

--- a/server/utils/supabase.js
+++ b/server/utils/supabase.js
@@ -1,0 +1,14 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.SUPABASE_URL || process.env.REACT_APP_SUPABASE_URL;
+const supabaseKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  process.env.SUPABASE_ANON_KEY ||
+  process.env.REACT_APP_SUPABASE_SERVICE_ROLE_KEY ||
+  process.env.REACT_APP_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.warn('⚠️ Supabase credentials not found. Some functionality may be limited.');
+}
+
+export const supabase = createClient(supabaseUrl || '', supabaseKey || '');


### PR DESCRIPTION
## Summary
- add resend helper to share email client between routes
- expose supabase client for API routes
- implement JWT token helpers in emails util

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f79e6f4fc8320a95a7c0d58c5eff1